### PR TITLE
feat: Add efficient subsequence extraction from contigs

### DIFF
--- a/SUBSEQUENCE_REQUIREMENTS.md
+++ b/SUBSEQUENCE_REQUIREMENTS.md
@@ -1,0 +1,82 @@
+# Sub-sequence Extraction Requirements
+
+## Problem
+
+Currently, `Decompressor::get_contig()` returns the entire contig as a `Vec<u8>`. When a caller only needs a small range (e.g., 1kb from a 200Mb chromosome), they must:
+
+1. Decompress all segments of the contig
+2. Reconstruct the full sequence in memory
+3. Slice the result to get the desired range
+
+This is inefficient for use cases like:
+- Fetching sequence context around alignment coordinates
+- Extracting regions for variant calling
+- Random access queries typical in genomic analysis
+
+## Proposed API
+
+Add range-based extraction methods to `Decompressor`:
+
+```rust
+/// Extract a subsequence from a contig
+///
+/// # Arguments
+/// * `sample_name` - The sample containing the contig
+/// * `contig_name` - The contig name
+/// * `start` - 0-based start position (inclusive)
+/// * `end` - 0-based end position (exclusive)
+///
+/// # Returns
+/// The subsequence as Vec<u8> in numeric encoding (0=A, 1=C, 2=G, 3=T)
+pub fn get_contig_range(
+    &mut self,
+    sample_name: &str,
+    contig_name: &str,
+    start: usize,
+    end: usize,
+) -> Result<Vec<u8>>
+
+/// Get the length of a contig without decompressing it
+///
+/// This should be O(1) if segment lengths are stored in metadata
+pub fn get_contig_length(
+    &mut self,
+    sample_name: &str,
+    contig_name: &str,
+) -> Result<usize>
+```
+
+## Implementation Considerations
+
+### Segment-aware extraction
+
+AGC stores contigs as sequences of ~60KB segments. For efficient range extraction:
+
+1. **Identify relevant segments**: Given `start` and `end`, determine which segments contain those positions
+2. **Decompress only needed segments**: Skip segments entirely outside the range
+3. **Partial segment handling**: For boundary segments, decompress fully but only keep the needed portion
+
+### Length calculation
+
+Contig length can be computed from segment metadata:
+- Sum of `raw_length` fields from `SegmentDesc` for each segment in the contig
+- This should be cached or computed without full decompression
+
+### Overlap handling
+
+Segments overlap by `kmer_length` bases. When reconstructing a range:
+- Account for overlap when calculating which segments are needed
+- Handle the k-mer overlap trimming at segment boundaries within the range
+
+## Use Case: impg
+
+impg uses AGC files to store reference sequences. Queries typically:
+- Fetch small ranges (hundreds to thousands of bases)
+- Make many queries against the same contigs
+- Need fast random access
+
+Current impg workaround fetches full contigs and slices them, which is memory-intensive for large chromosomes.
+
+## Priority
+
+High - this is a fundamental operation for any tool using AGC as a sequence store.

--- a/ragc-cli/src/main.rs
+++ b/ragc-cli/src/main.rs
@@ -402,7 +402,9 @@ fn main() -> Result<()> {
             output,
             format,
             verbosity,
-        } => getrange_command(archive, sample, contig, start, end, output, format, verbosity)?,
+        } => getrange_command(
+            archive, sample, contig, start, end, output, format, verbosity,
+        )?,
 
         Commands::Ctglen {
             archive,

--- a/ragc-cli/src/main.rs
+++ b/ragc-cli/src/main.rs
@@ -136,6 +136,54 @@ enum Commands {
         verbosity: u32,
     },
 
+    /// Extract a subsequence from a contig (efficient range query)
+    Getrange {
+        /// Input archive file path
+        archive: PathBuf,
+
+        /// Sample name containing the contig
+        #[arg(short = 's', long)]
+        sample: String,
+
+        /// Contig name
+        #[arg(short = 'c', long)]
+        contig: String,
+
+        /// Start position (0-based, inclusive)
+        #[arg(long)]
+        start: usize,
+
+        /// End position (0-based, exclusive). If omitted, extracts to end of contig.
+        #[arg(long)]
+        end: Option<usize>,
+
+        /// Output file (default: stdout)
+        #[arg(short = 'o', long)]
+        output: Option<PathBuf>,
+
+        /// Output format: fasta or raw (default: fasta)
+        #[arg(short = 'f', long, default_value = "fasta")]
+        format: String,
+
+        /// Verbosity level (0=quiet, 1=normal, 2=verbose)
+        #[arg(short = 'v', long, default_value_t = 0)]
+        verbosity: u32,
+    },
+
+    /// Get the length of a contig without extracting it
+    Ctglen {
+        /// Input archive file path
+        archive: PathBuf,
+
+        /// Sample name containing the contig
+        #[arg(short = 's', long)]
+        sample: String,
+
+        /// Contig name
+        #[arg(short = 'c', long)]
+        contig: String,
+    },
+
     /// List sample names in archive
     Listset {
         /// Input archive file path
@@ -344,6 +392,23 @@ fn main() -> Result<()> {
             output,
             verbosity,
         } => getset_command(archive, samples, prefix, output, verbosity)?,
+
+        Commands::Getrange {
+            archive,
+            sample,
+            contig,
+            start,
+            end,
+            output,
+            format,
+            verbosity,
+        } => getrange_command(archive, sample, contig, start, end, output, format, verbosity)?,
+
+        Commands::Ctglen {
+            archive,
+            sample,
+            contig,
+        } => ctglen_command(archive, sample, contig)?,
 
         Commands::Listset { archive, output } => listset_command(archive, output)?,
 
@@ -1153,6 +1218,92 @@ fn listctg_command(archive: PathBuf, samples: Vec<String>, output: Option<PathBu
             println!("{line}");
         }
     }
+
+    decompressor.close()?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn getrange_command(
+    archive: PathBuf,
+    sample: String,
+    contig: String,
+    start: usize,
+    end: Option<usize>,
+    output: Option<PathBuf>,
+    format: String,
+    verbosity: u32,
+) -> Result<()> {
+    use ragc_core::CNV_NUM;
+
+    let archive_str = archive
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid archive path"))?;
+
+    let config = DecompressorConfig { verbosity };
+    let mut decompressor = Decompressor::open(archive_str, config)?;
+
+    // Get end position (use contig length if not specified)
+    let end = match end {
+        Some(e) => e,
+        None => decompressor.get_contig_length(&sample, &contig)?,
+    };
+
+    if verbosity > 0 {
+        eprintln!(
+            "Extracting {}:{} range {}..{} ({} bp)",
+            sample,
+            contig,
+            start,
+            end,
+            end.saturating_sub(start)
+        );
+    }
+
+    // Extract the range
+    let sequence = decompressor.get_contig_range(&sample, &contig, start, end)?;
+
+    // Convert to ASCII
+    let ascii_seq: Vec<u8> = sequence
+        .iter()
+        .map(|&b| if b < 16 { CNV_NUM[b as usize] } else { b'N' })
+        .collect();
+
+    // Output
+    let output_data = if format == "raw" {
+        ascii_seq
+    } else {
+        // FASTA format
+        let header = format!(">{}:{} {}:{}-{}\n", sample, contig, contig, start, end);
+        let mut fasta = header.into_bytes();
+        // Wrap at 80 characters
+        for chunk in ascii_seq.chunks(80) {
+            fasta.extend_from_slice(chunk);
+            fasta.push(b'\n');
+        }
+        fasta
+    };
+
+    if let Some(output_path) = output {
+        std::fs::write(output_path, &output_data)?;
+    } else {
+        io::stdout().write_all(&output_data)?;
+    }
+
+    decompressor.close()?;
+    Ok(())
+}
+
+fn ctglen_command(archive: PathBuf, sample: String, contig: String) -> Result<()> {
+    let archive_str = archive
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid archive path"))?;
+
+    let config = DecompressorConfig { verbosity: 0 };
+    let mut decompressor = Decompressor::open(archive_str, config)?;
+
+    let length = decompressor.get_contig_length(&sample, &contig)?;
+    println!("{}", length);
 
     decompressor.close()?;
     Ok(())

--- a/ragc-core/src/genome_io.rs
+++ b/ragc-core/src/genome_io.rs
@@ -12,7 +12,9 @@ use ragc_common::Contig;
 
 /// Nucleotide conversion table matching C++ cnv_num
 /// Maps ASCII characters to numeric representation
-pub(crate) const CNV_NUM: [u8; 128] = [
+/// Index 0-15 maps numeric encoding to ASCII: CNV_NUM[0]='A', CNV_NUM[1]='C', etc.
+/// Index 65+ maps ASCII to numeric: CNV_NUM['A']='0', CNV_NUM['C']='1', etc.
+pub const CNV_NUM: [u8; 128] = [
     // 0-15: Control characters -> ACGT... (matching C++)
     b'A', b'C', b'G', b'T', b'N', b'R', b'Y', b'S', b'W', b'K', b'M', b'B', b'D', b'H', b'V', b'U',
     // 16-63: Unused

--- a/ragc-core/src/lib.rs
+++ b/ragc-core/src/lib.rs
@@ -560,7 +560,7 @@ pub mod ragc_ffi {
 pub use agc_compressor::{QueueStats, StreamingQueueCompressor, StreamingQueueConfig};
 pub use contig_iterator::{MultiFileIterator, PansnFileIterator};
 pub use decompressor::{Decompressor, DecompressorConfig};
-pub use genome_io::{GenomeIO, GenomeWriter};
+pub use genome_io::{GenomeIO, GenomeWriter, CNV_NUM};
 pub use kmer::{
     canonical_kmer, decode_base, encode_base, reverse_complement, reverse_complement_kmer,
 };

--- a/ragc-core/tests/test_subsequence.rs
+++ b/ragc-core/tests/test_subsequence.rs
@@ -16,8 +16,8 @@ fn create_test_archive(path: &str, contigs: Vec<(&str, &str, Vec<u8>)>) {
     };
 
     let splitters = AHashSet::new();
-    let mut compressor =
-        StreamingQueueCompressor::with_splitters(path, config, splitters).expect("Failed to create compressor");
+    let mut compressor = StreamingQueueCompressor::with_splitters(path, config, splitters)
+        .expect("Failed to create compressor");
 
     // Push all contigs
     for (sample, contig, data) in contigs {
@@ -48,8 +48,12 @@ fn test_get_contig_length() {
     let config = DecompressorConfig { verbosity: 0 };
     let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
 
-    let len1 = dec.get_contig_length("sample1", "chr1").expect("Failed to get length");
-    let len2 = dec.get_contig_length("sample1", "chr2").expect("Failed to get length");
+    let len1 = dec
+        .get_contig_length("sample1", "chr1")
+        .expect("Failed to get length");
+    let len2 = dec
+        .get_contig_length("sample1", "chr2")
+        .expect("Failed to get length");
 
     assert_eq!(len1, contig1_len, "chr1 length mismatch");
     assert_eq!(len2, contig2_len, "chr2 length mismatch");
@@ -77,17 +81,19 @@ fn test_get_contig_range_basic() {
     let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
 
     // Get full contig for comparison
-    let full_contig = dec.get_contig("sample1", "chr1").expect("Failed to get full contig");
+    let full_contig = dec
+        .get_contig("sample1", "chr1")
+        .expect("Failed to get full contig");
 
     // Test various ranges
     let test_cases = vec![
-        (0, 100),      // Beginning
-        (500, 600),    // Middle of first section
-        (900, 1100),   // Across A/C boundary
-        (2000, 3000),  // Middle (all G)
-        (3900, 4000),  // End
-        (0, 4000),     // Full range
-        (1000, 1001),  // Single base
+        (0, 100),     // Beginning
+        (500, 600),   // Middle of first section
+        (900, 1100),  // Across A/C boundary
+        (2000, 3000), // Middle (all G)
+        (3900, 4000), // End
+        (0, 4000),    // Full range
+        (1000, 1001), // Single base
     ];
 
     for (start, end) in test_cases {
@@ -165,16 +171,18 @@ fn test_get_contig_range_large_contig() {
     let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
 
     // Get full contig for comparison
-    let full_contig = dec.get_contig("sample1", "chr1").expect("Failed to get full contig");
+    let full_contig = dec
+        .get_contig("sample1", "chr1")
+        .expect("Failed to get full contig");
     assert_eq!(full_contig.len(), contig_size);
 
     // Test ranges across segment boundaries (~60KB segments)
     let test_cases = vec![
-        (0, 1000),           // First segment only
-        (59000, 61000),      // Across first segment boundary
-        (119000, 121000),    // Across second segment boundary
-        (250000, 260000),    // Middle
-        (490000, 500000),    // End
+        (0, 1000),        // First segment only
+        (59000, 61000),   // Across first segment boundary
+        (119000, 121000), // Across second segment boundary
+        (250000, 260000), // Middle
+        (490000, 500000), // End
     ];
 
     for (start, end) in test_cases {
@@ -201,7 +209,9 @@ fn test_get_contig_range_large_contig() {
     }
 
     // Verify length calculation
-    let reported_len = dec.get_contig_length("sample1", "chr1").expect("Failed to get length");
+    let reported_len = dec
+        .get_contig_length("sample1", "chr1")
+        .expect("Failed to get length");
     assert_eq!(reported_len, contig_size, "Length calculation mismatch");
 
     // Clean up

--- a/ragc-core/tests/test_subsequence.rs
+++ b/ragc-core/tests/test_subsequence.rs
@@ -1,0 +1,209 @@
+#![allow(clippy::all)]
+// Integration test for subsequence extraction
+// Tests get_contig_length() and get_contig_range()
+
+use ahash::AHashSet;
+use ragc_core::{Decompressor, DecompressorConfig, StreamingQueueCompressor, StreamingQueueConfig};
+use std::fs;
+
+fn create_test_archive(path: &str, contigs: Vec<(&str, &str, Vec<u8>)>) {
+    // Create compressor
+    let config = StreamingQueueConfig {
+        queue_capacity: 10 * 1024 * 1024,
+        num_threads: 1,
+        verbosity: 0,
+        ..Default::default()
+    };
+
+    let splitters = AHashSet::new();
+    let mut compressor =
+        StreamingQueueCompressor::with_splitters(path, config, splitters).expect("Failed to create compressor");
+
+    // Push all contigs
+    for (sample, contig, data) in contigs {
+        compressor
+            .push(sample.to_string(), contig.to_string(), data)
+            .expect("Failed to push contig");
+    }
+
+    compressor.finalize().expect("Failed to finalize");
+}
+
+#[test]
+fn test_get_contig_length() {
+    let archive_path = "/tmp/test_contig_length.agc";
+
+    // Create test data with known lengths
+    let contig1_len = 5000;
+    let contig2_len = 10000;
+
+    let contigs = vec![
+        ("sample1", "chr1", vec![0u8; contig1_len]), // A x 5000
+        ("sample1", "chr2", vec![1u8; contig2_len]), // C x 10000
+    ];
+
+    create_test_archive(archive_path, contigs);
+
+    // Test length retrieval
+    let config = DecompressorConfig { verbosity: 0 };
+    let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
+
+    let len1 = dec.get_contig_length("sample1", "chr1").expect("Failed to get length");
+    let len2 = dec.get_contig_length("sample1", "chr2").expect("Failed to get length");
+
+    assert_eq!(len1, contig1_len, "chr1 length mismatch");
+    assert_eq!(len2, contig2_len, "chr2 length mismatch");
+
+    // Clean up
+    fs::remove_file(archive_path).ok();
+}
+
+#[test]
+fn test_get_contig_range_basic() {
+    let archive_path = "/tmp/test_contig_range_basic.agc";
+
+    // Create a sequence with different bases at different positions
+    // Pattern: AAAAA...CCCCC...GGGGG...TTTTT... (1000 each)
+    let mut seq = Vec::with_capacity(4000);
+    seq.extend(vec![0u8; 1000]); // A
+    seq.extend(vec![1u8; 1000]); // C
+    seq.extend(vec![2u8; 1000]); // G
+    seq.extend(vec![3u8; 1000]); // T
+
+    let contigs = vec![("sample1", "chr1", seq.clone())];
+    create_test_archive(archive_path, contigs);
+
+    let config = DecompressorConfig { verbosity: 0 };
+    let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
+
+    // Get full contig for comparison
+    let full_contig = dec.get_contig("sample1", "chr1").expect("Failed to get full contig");
+
+    // Test various ranges
+    let test_cases = vec![
+        (0, 100),      // Beginning
+        (500, 600),    // Middle of first section
+        (900, 1100),   // Across A/C boundary
+        (2000, 3000),  // Middle (all G)
+        (3900, 4000),  // End
+        (0, 4000),     // Full range
+        (1000, 1001),  // Single base
+    ];
+
+    for (start, end) in test_cases {
+        let range_result = dec
+            .get_contig_range("sample1", "chr1", start, end)
+            .expect(&format!("Failed to get range {}..{}", start, end));
+
+        let expected = &full_contig[start..end];
+
+        assert_eq!(
+            range_result.len(),
+            expected.len(),
+            "Length mismatch for range {}..{}",
+            start,
+            end
+        );
+        assert_eq!(
+            range_result, expected,
+            "Content mismatch for range {}..{}",
+            start, end
+        );
+    }
+
+    // Clean up
+    fs::remove_file(archive_path).ok();
+}
+
+#[test]
+fn test_get_contig_range_edge_cases() {
+    let archive_path = "/tmp/test_contig_range_edge.agc";
+
+    let seq = vec![0u8; 1000];
+    let contigs = vec![("sample1", "chr1", seq)];
+    create_test_archive(archive_path, contigs);
+
+    let config = DecompressorConfig { verbosity: 0 };
+    let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
+
+    // Empty range (start >= end)
+    let empty1 = dec
+        .get_contig_range("sample1", "chr1", 100, 100)
+        .expect("Failed to get empty range");
+    assert!(empty1.is_empty(), "start==end should return empty");
+
+    let empty2 = dec
+        .get_contig_range("sample1", "chr1", 200, 100)
+        .expect("Failed to get reverse range");
+    assert!(empty2.is_empty(), "start>end should return empty");
+
+    // End beyond contig length (should clamp)
+    let clamped = dec
+        .get_contig_range("sample1", "chr1", 900, 2000)
+        .expect("Failed to get clamped range");
+    assert_eq!(clamped.len(), 100, "Should clamp to contig length");
+
+    // Clean up
+    fs::remove_file(archive_path).ok();
+}
+
+#[test]
+fn test_get_contig_range_large_contig() {
+    let archive_path = "/tmp/test_contig_range_large.agc";
+
+    // Create a 500KB contig (multiple segments)
+    let contig_size = 500_000;
+    let mut seq = Vec::with_capacity(contig_size);
+    for i in 0..contig_size {
+        seq.push((i % 4) as u8);
+    }
+
+    let contigs = vec![("sample1", "chr1", seq.clone())];
+    create_test_archive(archive_path, contigs);
+
+    let config = DecompressorConfig { verbosity: 0 };
+    let mut dec = Decompressor::open(archive_path, config).expect("Failed to open archive");
+
+    // Get full contig for comparison
+    let full_contig = dec.get_contig("sample1", "chr1").expect("Failed to get full contig");
+    assert_eq!(full_contig.len(), contig_size);
+
+    // Test ranges across segment boundaries (~60KB segments)
+    let test_cases = vec![
+        (0, 1000),           // First segment only
+        (59000, 61000),      // Across first segment boundary
+        (119000, 121000),    // Across second segment boundary
+        (250000, 260000),    // Middle
+        (490000, 500000),    // End
+    ];
+
+    for (start, end) in test_cases {
+        let range_result = dec
+            .get_contig_range("sample1", "chr1", start, end)
+            .expect(&format!("Failed to get range {}..{}", start, end));
+
+        let expected = &full_contig[start..end];
+
+        assert_eq!(
+            range_result.len(),
+            expected.len(),
+            "Length mismatch for range {}..{}: got {}, expected {}",
+            start,
+            end,
+            range_result.len(),
+            expected.len()
+        );
+        assert_eq!(
+            range_result, expected,
+            "Content mismatch for range {}..{}",
+            start, end
+        );
+    }
+
+    // Verify length calculation
+    let reported_len = dec.get_contig_length("sample1", "chr1").expect("Failed to get length");
+    assert_eq!(reported_len, contig_size, "Length calculation mismatch");
+
+    // Clean up
+    fs::remove_file(archive_path).ok();
+}


### PR DESCRIPTION
## Summary

This PR implements efficient range-based extraction from AGC archives, allowing extraction of subsequences without decompressing entire contigs.

- **`get_contig_length()`**: O(1) length calculation from segment metadata
- **`get_contig_range()`**: Only decompresses segments that overlap the requested range
- **CLI `getrange` command**: Extract subsequences with `--start` and `--end` positions
- **CLI `ctglen` command**: Query contig length without extraction

### Use cases
- Fetching sequence context around alignment coordinates
- Extracting regions for variant calling
- Random access queries typical in genomic analysis (impg use case)

## Test plan
- [x] Added `test_subsequence.rs` with 4 tests covering:
  - Basic length calculation
  - Range extraction across various positions
  - Edge cases (empty ranges, clamping)
  - Large contigs spanning multiple segments
- [x] Verified CLI commands work with real archives
- [x] All existing tests pass